### PR TITLE
Support for arbitrary binary message retrieval by Spark Streaming from RabbitMQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,17 +149,6 @@
             <artifactId>spark-streaming_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
-        <dependency>
-			<groupId>com.github.samtools</groupId>
-			<artifactId>htsjdk</artifactId>
-			<version>1.136</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.4</version>
-		</dependency>
-		
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,17 @@
             <artifactId>spark-streaming_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
+        <dependency>
+			<groupId>com.github.samtools</groupId>
+			<artifactId>htsjdk</artifactId>
+			<version>1.136</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.4</version>
+		</dependency>
+		
     </dependencies>
 
     <build>

--- a/src/main/scala/com/stratio/receiver/RabbitMQInputDStream.scala
+++ b/src/main/scala/com/stratio/receiver/RabbitMQInputDStream.scala
@@ -26,9 +26,13 @@ import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.ReceiverInputDStream
 import org.apache.spark.streaming.receiver.Receiver
+import java.nio.ByteBuffer
+import scala.reflect.{classTag, ClassTag}
+import htsjdk.samtools._
+import org.apache.commons.lang3.SerializationUtils
 
 private[receiver]
-class RabbitMQInputDStream(
+class RabbitMQInputDStream[R : ClassTag](
                             @transient ssc_ : StreamingContext,
                             rabbitMQQueueName: Option[String],
                             rabbitMQHost: String,
@@ -36,9 +40,9 @@ class RabbitMQInputDStream(
                             exchangeName: Option[String],
                             routingKeys: Seq[String],
                             storageLevel: StorageLevel
-                            ) extends ReceiverInputDStream[String](ssc_) with Logging {
+                            ) extends ReceiverInputDStream[R](ssc_) with Logging {
 
-  override def getReceiver(): Receiver[String] = {
+  override def getReceiver(): Receiver[R] = {
     val DefaultRabbitMQPort = 5672
 
     new RabbitMQReceiver(rabbitMQQueueName,
@@ -51,13 +55,13 @@ class RabbitMQInputDStream(
 }
 
 private[receiver]
-class RabbitMQReceiver(rabbitMQQueueName: Option[String],
+class RabbitMQReceiver[R: ClassTag](rabbitMQQueueName: Option[String],
                        rabbitMQHost: String,
                        rabbitMQPort: Int,
                        exchangeName: Option[String],
                        routingKeys: Seq[String],
                        storageLevel: StorageLevel)
-  extends Receiver[String](storageLevel) with Logging {
+  extends Receiver[R](storageLevel) with Logging {
 
   val DirectExchangeType: String = "direct"
 
@@ -99,7 +103,7 @@ class RabbitMQReceiver(rabbitMQQueueName: Option[String],
 
     while (!isStopped) {
       val delivery: QueueingConsumer.Delivery = consumer.nextDelivery
-      store(new String(delivery.getBody))
+      store(ByteBuffer.wrap(delivery.getBody,0, delivery.getBody.length))
     }
 
     log.info("it has been stopped")

--- a/src/main/scala/com/stratio/receiver/RabbitMQInputDStream.scala
+++ b/src/main/scala/com/stratio/receiver/RabbitMQInputDStream.scala
@@ -28,8 +28,6 @@ import org.apache.spark.streaming.dstream.ReceiverInputDStream
 import org.apache.spark.streaming.receiver.Receiver
 import java.nio.ByteBuffer
 import scala.reflect.{classTag, ClassTag}
-import htsjdk.samtools._
-import org.apache.commons.lang3.SerializationUtils
 
 private[receiver]
 class RabbitMQInputDStream[R : ClassTag](

--- a/src/main/scala/com/stratio/receiver/RabbitMQUtils.scala
+++ b/src/main/scala/com/stratio/receiver/RabbitMQUtils.scala
@@ -38,7 +38,7 @@ object RabbitMQUtils {
                    rabbitMQPort: Int,
                    rabbitMQQueueName: String,
                    storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
-                    ): ReceiverInputDStream[String] = {
+                    ): ReceiverInputDStream[ClassTag[AnyRef]] = {
     new RabbitMQInputDStream(
       ssc,
       Some(rabbitMQQueueName),
@@ -62,8 +62,7 @@ object RabbitMQUtils {
                    rabbitMQPort: Int,
                    rabbitMQQueueName: String,
                    storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
-                    ): JavaReceiverInputDStream[String] = {
-    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
+                    ): JavaReceiverInputDStream[ClassTag[AnyRef]] = {
     createStreamFromAQueue(jssc.ssc, rabbitMQHost, rabbitMQPort, rabbitMQQueueName)
   }
 
@@ -82,7 +81,7 @@ object RabbitMQUtils {
                    exchangeName: String,
                    routingKeys: Seq[String],
                    storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
-                    ): ReceiverInputDStream[String] = {
+                    ): ReceiverInputDStream[ClassTag[AnyRef]] = {
     new RabbitMQInputDStream(
       ssc,
       None,
@@ -108,8 +107,7 @@ object RabbitMQUtils {
                                   exchangeName: String,
                                   routingKeys: java.util.List[String],
                                   storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
-                                   ): JavaReceiverInputDStream[String] = {
-    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
+                                   ): JavaReceiverInputDStream[ClassTag[AnyRef]] = {
     createStreamFromRoutingKeys(jssc.ssc, rabbitMQHost, rabbitMQPort, exchangeName, scala.collection.JavaConversions
       .asScalaBuffer(routingKeys), storageLevel)
   }


### PR DESCRIPTION
Replace implicit conversion of RabbitMQ messages to String by java.nio.BytBuffer backed mechanism.

This PR may require additional work by authors as I'm a complete Scala newbie. I could successfully confirm receipt and storage of messages on the client-side but continue having difficulties deserializing my objects from the resultant RDD as detailed here - http://stackoverflow.com/questions/31622749/consuming-rabbitmq-messages-with-spark-streaming