### PR TITLE
Check if a connection is still open before attempting to close it.

### DIFF
--- a/src/main/scala/org/apache/spark/streaming/rabbitmq/consumer/Consumer.scala
+++ b/src/main/scala/org/apache/spark/streaming/rabbitmq/consumer/Consumer.scala
@@ -209,7 +209,8 @@ object Consumer extends Logging with ConsumerParamsUtils {
    */
   def closeConnections(): Unit =
     connections.foreach{case (key, connection) =>
-      connection.close()
+      if (connection.isOpen)
+        connection.close()
       connections.remove(key)
     }
 


### PR DESCRIPTION
If `Connection.close()` is called on an already closed `Connection`, a `com.rabbitmq.client.AlreadyClosedException` is thrown in `Consumer.closeConnections()`.

I actually stumbled upon this problem after finding that connection recovery was not working.
Indeed, when a RabbitMQ instance becomes unreachable for an instant but comes back moments later (reproducible by stopping and then restarting it for example while the consumer is still running):

1. `RabbitMQReceiver.onStart()` fails with "org.apache.spark.SparkException: Error creating channel and connection: connection is already closed due to connection error; cause: java.net.SocketException: Connection reset" and tries to restart the receiver with a "Could not connect" message
2. When the receiver is being stopped, the `com.rabbitmq.client.AlreadyClosedException` is thrown in `Consumer.closeConnections()`
3. Because of this Exception, `connections.remove(key)` is not called meaning that the closed `Connection` is kept
4. When the RabbitMQ instance is back, the same closed `Connection` instance is used thus we end up in the same situation than in point 1

To exit this loop, we had to restart the spark-streaming RabbitMQ consumer.
However, by avoiding the `AlreadyClosedException`, connection recovery do work as expected, because `connections.remove(key)` is properly called and the `Connection` object is renewed when necessary.