### PR TITLE
Store Delivery objects instead of just their bodies: This enable clients to receive message properties

### DIFF
--- a/src/main/scala/org/apache/spark/streaming/rabbitmq/RabbitMQUtils.scala
+++ b/src/main/scala/org/apache/spark/streaming/rabbitmq/RabbitMQUtils.scala
@@ -17,6 +17,7 @@ package org.apache.spark.streaming.rabbitmq
 
 import java.util.{List => JList, Map => JMap}
 
+import com.rabbitmq.client.QueueingConsumer.Delivery
 import org.apache.spark.api.java.function.{Function => JFunction}
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.api.java.{JavaInputDStream, JavaReceiverInputDStream, JavaStreamingContext}
@@ -39,7 +40,7 @@ object RabbitMQUtils {
   def createStream[R: ClassTag](
                                  ssc: StreamingContext,
                                  params: Map[String, String],
-                                 messageHandler: Array[Byte] => R
+                                 messageHandler: Delivery => R
                                ): ReceiverInputDStream[R] = {
     new RabbitMQInputDStream[R](ssc, params, messageHandler)
   }
@@ -55,7 +56,7 @@ object RabbitMQUtils {
                     ssc: StreamingContext,
                     params: Map[String, String]
                   ): ReceiverInputDStream[Array[Byte]] = {
-    val messageHandler = (rawMessage: Array[Byte]) => rawMessage
+    val messageHandler = (rawMessage: Delivery) => rawMessage.getBody
 
     new RabbitMQInputDStream[Array[Byte]](ssc, params, messageHandler)
   }
@@ -71,7 +72,7 @@ object RabbitMQUtils {
                                                       ssc: StreamingContext,
                                                       params: Map[String, String]
                                                     ): ReceiverInputDStream[String] = {
-    val messageHandler = (rawMessage: Array[Byte]) => new Predef.String(rawMessage)
+    val messageHandler = (rawMessage: Delivery) => new Predef.String(rawMessage.getBody)
 
     new RabbitMQInputDStream[String](ssc, params, messageHandler)
   }
@@ -88,7 +89,7 @@ object RabbitMQUtils {
                            javaStreamingContext: JavaStreamingContext,
                            recordClass: Class[R],
                            params: JMap[String, String],
-                           messageHandler: JFunction[Array[Byte], R]
+                           messageHandler: JFunction[Delivery, R]
                          ): JavaReceiverInputDStream[R] = {
 
     implicit val recordCmt: ClassTag[R] = ClassTag(recordClass)

--- a/src/main/scala/org/apache/spark/streaming/rabbitmq/RabbitMQUtils.scala
+++ b/src/main/scala/org/apache/spark/streaming/rabbitmq/RabbitMQUtils.scala
@@ -118,7 +118,7 @@ object RabbitMQUtils {
                                             ssc: StreamingContext,
                                             distributedKeys: Seq[RabbitMQDistributedKey],
                                             rabbitMQParams: Map[String, String],
-                                            messageHandler: Array[Byte] => R
+                                            messageHandler: Delivery => R
                                           ): InputDStream[R] = {
     val cleanedHandler = ssc.sc.clean(messageHandler)
 
@@ -142,7 +142,7 @@ object RabbitMQUtils {
                                distributedKeys: Seq[RabbitMQDistributedKey],
                                rabbitMQParams: Map[String, String]
                              ): InputDStream[Array[Byte]] = {
-    val messageHandler = (rawMessage: Array[Byte]) => rawMessage
+    val messageHandler = (rawMessage: Delivery) => rawMessage.getBody
 
     new RabbitMQDStream[Array[Byte]](ssc, distributedKeys, rabbitMQParams, messageHandler)
   }
@@ -166,7 +166,7 @@ object RabbitMQUtils {
                                                                  distributedKeys: Seq[RabbitMQDistributedKey],
                                                                  rabbitMQParams: Map[String, String]
                                                                ): InputDStream[String] = {
-    val messageHandler = (rawMessage: Array[Byte]) => new Predef.String(rawMessage)
+    val messageHandler = (rawMessage: Delivery) => new Predef.String(rawMessage.getBody)
 
     new RabbitMQDStream[String](ssc, distributedKeys, rabbitMQParams, messageHandler)
   }
@@ -192,7 +192,7 @@ object RabbitMQUtils {
                                   recordClass: Class[R],
                                   distributedKeys: JList[JavaRabbitMQDistributedKey],
                                   rabbitMQParams: JMap[String, String],
-                                  messageHandler: JFunction[Array[Byte], R]
+                                  messageHandler: JFunction[Delivery, R]
                                 ): JavaInputDStream[R] = {
     implicit val recordCmt: ClassTag[R] = ClassTag(recordClass)
     val cleanedHandler = javaStreamingContext.sparkContext.clean(messageHandler.call _)

--- a/src/main/scala/org/apache/spark/streaming/rabbitmq/distributed/RabbitMQDStream.scala
+++ b/src/main/scala/org/apache/spark/streaming/rabbitmq/distributed/RabbitMQDStream.scala
@@ -24,6 +24,7 @@ import org.apache.spark.streaming.scheduler.{RateController, StreamInputInfo}
 import org.apache.spark.streaming.{Seconds, StreamingContext, Time}
 import org.apache.spark.{Accumulator, Logging}
 import RabbitMQDStream._
+import com.rabbitmq.client.QueueingConsumer.Delivery
 
 import scala.reflect.ClassTag
 
@@ -32,7 +33,7 @@ class RabbitMQDStream[R: ClassTag](
                                     @transient val _ssc: StreamingContext,
                                     val distributedKeys: Seq[RabbitMQDistributedKey],
                                     val rabbitMQParams: Map[String, String],
-                                    messageHandler: Array[Byte] => R
+                                    messageHandler: Delivery => R
                                   ) extends InputDStream[R](_ssc) with Logging {
 
   private[streaming] override def name: String = s"RabbitMQ direct stream [$id]"

--- a/src/test/java/org/apache/spark/streaming/rabbitmq/JavaRabbitMQConsumer.java
+++ b/src/test/java/org/apache/spark/streaming/rabbitmq/JavaRabbitMQConsumer.java
@@ -15,6 +15,7 @@
  */
 package org.apache.spark.streaming.rabbitmq;
 
+import com.rabbitmq.client.QueueingConsumer.Delivery;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.streaming.Duration;
@@ -40,10 +41,10 @@ public final class JavaRabbitMQConsumer {
         params.put("userName", "guest");
         params.put("password", "guest");
 
-        Function<byte[], String> messageHandler = new Function<byte[], String>() {
+        Function<Delivery, String> messageHandler = new Function<Delivery, String>() {
 
-            public String call(byte[] message) {
-                return new String(message);
+            public String call(Delivery message) {
+                return new String(message.getBody());
             }
         };
 

--- a/src/test/java/org/apache/spark/streaming/rabbitmq/JavaRabbitMQDistributedConsumer.java
+++ b/src/test/java/org/apache/spark/streaming/rabbitmq/JavaRabbitMQDistributedConsumer.java
@@ -15,6 +15,7 @@
  */
 package org.apache.spark.streaming.rabbitmq;
 
+import com.rabbitmq.client.QueueingConsumer.Delivery;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.streaming.Duration;
@@ -48,10 +49,10 @@ public final class JavaRabbitMQDistributedConsumer implements Serializable {
                 params
         ));
 
-        Function<byte[], String> messageHandler = new Function<byte[], String>() {
+        Function<Delivery, String> messageHandler = new Function<Delivery, String>() {
 
-            public String call(byte[] message) {
-                return new String(message);
+            public String call(Delivery message) {
+                return new String(message.getBody());
             }
         };
 


### PR DESCRIPTION
In regard to #51, the idea is to store `com.rabbitmq.client.QueueingConsumer.Delivery` objects in Spark instead of just their bodies.

For example, by executing the following code...

```
import com.rabbitmq.client.QueueingConsumer.Delivery
import org.apache.spark.streaming.rabbitmq.RabbitMQUtils
import org.apache.spark.streaming.rabbitmq.distributed.RabbitMQDistributedKey
import org.apache.spark.streaming.{Seconds, StreamingContext}
import org.apache.spark.{SparkConf, SparkContext}

object Sandbox {
    def main(args: Array[String]): Unit = {
        val conf: SparkConf = new SparkConf()
        val sc: SparkContext = new SparkContext(conf)
        val ssc: StreamingContext = new StreamingContext(sc, Seconds(5))

        val params: Map[String, String] = Map(
            "hosts" -> "localhost",
            "virtualHosts" -> "/",
            "port" -> "5672",
            "userName" -> "admin",
            "password" -> "admin",
            "queueName" -> "test"
        )
        val distributedKeys = Seq(
            RabbitMQDistributedKey(
                queue = "test",
                connectionParams = params
            )
        )

        val stream = RabbitMQUtils.createDistributedStream(ssc, distributedKeys, params, (delivery: Delivery) => delivery)
        stream.foreachRDD{rdd => {
            rdd.foreach{delivery => {
                println(s"> delivery.toString: ${delivery.toString}")
                println(s"> delivery.getEnvelope.getRoutingKey: ${delivery.getEnvelope.getRoutingKey}")
                println(s"> delivery.getProperties.getHeaders.toString: ${delivery.getProperties.getHeaders.toString}")
                println(s"> delivery.getProperties.getMessageId: ${delivery.getProperties.getMessageId}")
                println(s"> delivery.getBody: ${new String(delivery.getBody)}")
            }}
        }}
        ssc.start()
        ssc.awaitTermination()
    }
}
```

... We do read `com.rabbitmq.client.QueueingConsumer.Delivery` objects and can access to their properties, as expected:

```
> delivery.toString: com.rabbitmq.client.QueueingConsumer$Delivery@316d3aa6
> delivery.getEnvelope.getRoutingKey: test
> delivery.getProperties.getHeaders.toString: {key=value}
> delivery.getProperties.getMessageId: message_id
> delivery.getBody: Hello world!
```

Unfortunately, these modifications break backwards compatibility because of the new `messageHandler()` signature.

As such, I am only interested in feedbacks about this approach and would like to know if this might have a chance to be merged in the future.
