### PR TITLE
nack messages we didn't process

### DIFF
--- a/src/main/scala/org/apache/spark/streaming/rabbitmq/distributed/RabbitMQRDD.scala
+++ b/src/main/scala/org/apache/spark/streaming/rabbitmq/distributed/RabbitMQRDD.scala
@@ -17,6 +17,7 @@ package org.apache.spark.streaming.rabbitmq.distributed
 
 import akka.actor.ActorSystem
 import com.rabbitmq.client.ConsumerCancelledException
+import com.rabbitmq.client.QueueingConsumer.Delivery
 import com.typesafe.config.ConfigFactory
 import org.apache.spark.partial.{BoundedDouble, CountEvaluator, PartialResult}
 import org.apache.spark.rdd.RDD
@@ -185,18 +186,10 @@ class RabbitMQRDD[R: ClassTag](
         if (finished || (maxMessagesPerPartition.isDefined && numMessages >= maxMessagesPerPartition.get)) {
           finishIterationAndReturn()
         } else {
-          Try {
-            val delivery = queueConsumer.nextDelivery()
-
-            (delivery, messageHandler(delivery.getBody))
-          } match {
-            case Success((delivery, data)) =>
-              //Send ack if not set the auto ack property
-              if (sendingBasicAckFromParams(rabbitParams))
-                consumer.sendBasicAck(delivery)
-              //Increment the number of messages consumed correctly
-              numMessages += 1
-              data
+          Try(queueConsumer.nextDelivery())
+          match {
+            case Success(delivery) =>
+              processDelivery(delivery)
             case Failure(e: ConsumerCancelledException) =>
               finishIterationAndReturn()
             case Failure(e) =>
@@ -207,6 +200,26 @@ class RabbitMQRDD[R: ClassTag](
               throw new SparkException(s"Error receiving data from RabbitMQ with error: ${e.getLocalizedMessage}")
           }
         }
+      }
+    }
+
+    private def processDelivery(delivery:Delivery): R = {
+      Try(messageHandler(delivery.getBody))
+      match {
+        case Success(data) =>
+          //Send ack if not set the auto ack property
+          if (sendingBasicAckFromParams(rabbitParams))
+            consumer.sendBasicAck(delivery)
+          //Increment the number of messages consumed correctly
+          numMessages += 1
+          data
+        case Failure(e) =>
+          //Send noack if not set the auto ack property
+          if (sendingBasicAckFromParams(rabbitParams)) {
+            log.warn(s"failed to process message. Sending noack ...")
+            consumer.sendBasicNAck(delivery)
+          }
+          null.asInstanceOf[R]
       }
     }
 

--- a/src/main/scala/org/apache/spark/streaming/rabbitmq/receiver/RabbitMQInputDStream.scala
+++ b/src/main/scala/org/apache/spark/streaming/rabbitmq/receiver/RabbitMQInputDStream.scala
@@ -15,6 +15,7 @@
  */
 package org.apache.spark.streaming.rabbitmq.receiver
 
+import com.rabbitmq.client.QueueingConsumer.Delivery
 import com.rabbitmq.client._
 import org.apache.spark.Logging
 import org.apache.spark.storage.StorageLevel
@@ -87,12 +88,13 @@ class RabbitMQReceiver[R: ClassTag](
     try {
       log.info("RabbitMQ consumer start consuming data")
       while (!isStopped() && consumer.channel.isOpen) {
-        val delivery = queueConsumer.nextDelivery()
-
-        store(messageHandler(delivery.getBody))
-
-        if (sendingBasicAckFromParams(params))
-          consumer.sendBasicAck(delivery)
+        Try(queueConsumer.nextDelivery())
+        match {
+          case Success(delivery) =>
+            processDelivery(consumer, delivery)
+          case Failure(e) =>
+            throw new Exception(s"An error occured while getting next delivery: ${e.getLocalizedMessage}")
+        }
       }
     } catch {
       case unknown: Throwable =>
@@ -107,6 +109,22 @@ class RabbitMQReceiver[R: ClassTag](
           log.error(s"error on close consumer, ignoring it : ${e.getLocalizedMessage}")
       }
       restart("Trying to connect again")
+    }
+  }
+
+  private def processDelivery(consumer: Consumer, delivery:Delivery) {
+    Try(store(messageHandler(delivery.getBody)))
+    match {
+      case Success(data) =>
+        //Send ack if not set the auto ack property
+        if (sendingBasicAckFromParams(params))
+          consumer.sendBasicAck(delivery)
+      case Failure(e) =>
+        //Send noack if not set the auto ack property
+        if (sendingBasicAckFromParams(params)) {
+          log.warn(s"failed to process message. Sending noack ...")
+          consumer.sendBasicNAck(delivery)
+        }
     }
   }
 }


### PR DESCRIPTION
If ackMode is set to basic, we have to nack messages we didn't process in order to requeue them.

Otherwise we will have unacknowledge messages in the queue ... and if fairDispatch is set to true, the channel will be stuck as soon as the number of unacked messages reach the prefectCount.