### PR TITLE
Upgrading to akka 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <scala.binary.version>2.11</scala.binary.version>
         <rabbitmq.version>3.6.6</rabbitmq.version>
         <spark.version>2.0.2</spark.version>
-        <akka.version>2.4.11</akka.version>
+        <akka.version>2.5.1</akka.version>
         <joda.version>2.8.2</joda.version>
         <scalatest.version>2.2.2</scalatest.version>
         <junit.version>4.8.1</junit.version>

--- a/src/main/scala/org/apache/spark/streaming/rabbitmq/distributed/RabbitMQRDD.scala
+++ b/src/main/scala/org/apache/spark/streaming/rabbitmq/distributed/RabbitMQRDD.scala
@@ -276,7 +276,7 @@ object RabbitMQRDD extends Logging {
 
   def getActorSystem: ActorSystem = {
     synchronized {
-      if (system.isEmpty || (system.isDefined && system.get.isTerminated))
+      if (system.isEmpty || (system.isDefined && system.get.whenTerminated.isCompleted))
         system = Option(akka.actor.ActorSystem(
           s"system-${System.currentTimeMillis()}",
           ConfigFactory.load(ConfigFactory.parseString("akka.daemonic=on"))
@@ -289,7 +289,7 @@ object RabbitMQRDD extends Logging {
     synchronized {
       system.foreach(actorSystem => {
         log.debug(s"Shutting down actor system: ${actorSystem.name}")
-        actorSystem.shutdown()
+        actorSystem.terminate()
         system = None
       })
     }

--- a/src/test/scala/org/apache/spark/streaming/rabbitmq/TemporalDataSuite.scala
+++ b/src/test/scala/org/apache/spark/streaming/rabbitmq/TemporalDataSuite.scala
@@ -168,6 +168,6 @@ private[rabbitmq] trait TemporalDataSuite extends RabbitMQSuite with BeforeAndAf
   }
 
   override def afterAll : Unit = {
-    system.shutdown()
+    system.terminate()
   }
 }


### PR DESCRIPTION
Hi, I tried to upgrade to akka 2.5.1 due to compatibility issues. It looks like only minor changes were needed. Let me know if you can approve this and maybe include it in a new release.
Thanks!