### PR TITLE
Change from pom to jar packaging to build JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <groupId>com.stratio.receiver</groupId>
     <artifactId>spark-rabbitmq</artifactId>
     <version>0.6.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
 
     <url>https://github.com/Stratio/RabbitMQ-Receiver</url>


### PR DESCRIPTION
Changing from pom to jar packaging to be able to build jar file. Uncertain why this was left as pom, since the project does not contain any other modules.